### PR TITLE
避免内存逃逸

### DIFF
--- a/event.go
+++ b/event.go
@@ -27,24 +27,24 @@ type BasicEvent struct {
 }
 
 // NewBasic new a basic event instance
-func NewBasic(name string, data M) *BasicEvent {
+func NewBasic(name string, data M) BasicEvent {
 	if data == nil {
 		data = make(map[string]interface{})
 	}
 
-	return &BasicEvent{
+	return BasicEvent{
 		name: name,
 		data: data,
 	}
 }
 
 // Abort event loop exec
-func (e *BasicEvent) Abort(abort bool) {
+func (e BasicEvent) Abort(abort bool) {
 	e.aborted = abort
 }
 
 // Fill event data
-func (e *BasicEvent) Fill(target interface{}, data M) *BasicEvent {
+func (e BasicEvent) Fill(target interface{}, data M) BasicEvent {
 	if data != nil {
 		e.data = data
 	}
@@ -54,12 +54,12 @@ func (e *BasicEvent) Fill(target interface{}, data M) *BasicEvent {
 }
 
 // AttachTo add current event to the event manager.
-func (e *BasicEvent) AttachTo(em ManagerFace) {
+func (e BasicEvent) AttachTo(em ManagerFace) {
 	em.AddEvent(e)
 }
 
 // Get data by index
-func (e *BasicEvent) Get(key string) interface{} {
+func (e BasicEvent) Get(key string) interface{} {
 	if v, ok := e.data[key]; ok {
 		return v
 	}
@@ -68,14 +68,14 @@ func (e *BasicEvent) Get(key string) interface{} {
 }
 
 // Add value by key
-func (e *BasicEvent) Add(key string, val interface{}) {
+func (e BasicEvent) Add(key string, val interface{}) {
 	if _, ok := e.data[key]; !ok {
 		e.Set(key, val)
 	}
 }
 
 // Set value by key
-func (e *BasicEvent) Set(key string, val interface{}) {
+func (e BasicEvent) Set(key string, val interface{}) {
 	if e.data == nil {
 		e.data = make(map[string]interface{})
 	}
@@ -84,33 +84,33 @@ func (e *BasicEvent) Set(key string, val interface{}) {
 }
 
 // Name get event name
-func (e *BasicEvent) Name() string {
+func (e BasicEvent) Name() string {
 	return e.name
 }
 
 // Data get all data
-func (e *BasicEvent) Data() map[string]interface{} {
+func (e BasicEvent) Data() map[string]interface{} {
 	return e.data
 }
 
 // IsAborted check.
-func (e *BasicEvent) IsAborted() bool {
+func (e BasicEvent) IsAborted() bool {
 	return e.aborted
 }
 
 // Target get target
-func (e *BasicEvent) Target() interface{} {
+func (e BasicEvent) Target() interface{} {
 	return e.target
 }
 
 // SetName set event name
-func (e *BasicEvent) SetName(name string) *BasicEvent {
+func (e BasicEvent) SetName(name string) BasicEvent {
 	e.name = name
 	return e
 }
 
 // SetData set data to the event
-func (e *BasicEvent) SetData(data M) Event {
+func (e BasicEvent) SetData(data M) Event {
 	if data != nil {
 		e.data = data
 	}
@@ -118,7 +118,7 @@ func (e *BasicEvent) SetData(data M) Event {
 }
 
 // SetTarget set event target
-func (e *BasicEvent) SetTarget(target interface{}) *BasicEvent {
+func (e BasicEvent) SetTarget(target interface{}) BasicEvent {
 	e.target = target
 	return e
 }


### PR DESCRIPTION
未修改前:

```text
goos: windows
goarch: amd64
pkg: github.com/gookit/event
cpu: Intel(R) Core(TM) i5-10400F CPU @ 2.90GHz
BenchmarkManager_Fire_no_listener
BenchmarkManager_Fire_no_listener-12             3589737               334.2 ns/
op            72 B/op          2 allocs/op
BenchmarkManager_Fire_normal
BenchmarkManager_Fire_normal-12                  3587448               335.9 ns/
op            72 B/op          2 allocs/op
BenchmarkManager_Fire_wildcard
BenchmarkManager_Fire_wildcard-12                2982114               379.5 ns/
op            72 B/op          2 allocs/op
PASS
```

修改后:

```text
goos: windows
goarch: amd64
pkg: github.com/gookit/event
cpu: Intel(R) Core(TM) i5-10400F CPU @ 2.90GHz
BenchmarkManager_Fire_no_listener
BenchmarkManager_Fire_no_listener-12             4655372               256.5 ns/
op            48 B/op          1 allocs/op
BenchmarkManager_Fire_normal
BenchmarkManager_Fire_normal-12                  4646497               256.8 ns/
op            48 B/op          1 allocs/op
BenchmarkManager_Fire_wildcard
BenchmarkManager_Fire_wildcard-12                3997699               294.7 ns/
op            48 B/op          1 allocs/op
PASS
```
